### PR TITLE
Fix for USER PUT routes

### DIFF
--- a/express_cut/express_service/models.py
+++ b/express_cut/express_service/models.py
@@ -9,12 +9,12 @@ class User(AbstractUser):
     CUSTOMER = 2
     ADMIN = 3
 
-    ROLE_CHOICES = (
+    ROLE_CHOICES = [
         (MANAGER, 'Manager'),
         (STYLIST, 'Stylist'),
         (CUSTOMER, 'Customer'),
         (ADMIN, 'Admin'),
-    )
+    ]
 
     role = models.PositiveSmallIntegerField(choices=ROLE_CHOICES, default=CUSTOMER)
 

--- a/express_cut/express_service/serializers.py
+++ b/express_cut/express_service/serializers.py
@@ -3,17 +3,21 @@ from .models import User, Service, DailySchedule, Reservation, TimeSlot
 from django.contrib.auth.hashers import make_password
 
 
-class UserSerializer(serializers.ModelSerializer):
-    role = serializers.ChoiceField(choices=User.ROLE_CHOICES)
-    pk = serializers.PrimaryKeyRelatedField(read_only=True)
-    password = serializers.CharField(write_only=True, required=True)
+class GeneralUserSerializer(serializers.ModelSerializer):
+    id = serializers.PrimaryKeyRelatedField(read_only=True)
 
-    # TODO: For PUT HTTP methods fields don't need to be required
-    # TODO: Roles cant be updated to other roles on put.
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'first_name', 'last_name', 'email', 'role']
+
+
+class SingUpUserSerializer(GeneralUserSerializer):
+    role = serializers.ChoiceField(choices=User.ROLE_CHOICES)
+    password = serializers.CharField(write_only=True, required=True)
     
     class Meta:
         model = User
-        fields = ['pk', 'username', 'first_name', 'last_name', 'email', 'role', 'password']
+        fields = ['id', 'username', 'first_name', 'last_name', 'email', 'role', 'password']
 
     def create(self, validated_data):
         validated_data['password'] = make_password(validated_data.get('password'))
@@ -27,25 +31,25 @@ class TimeSlotSerializer(serializers.ModelSerializer):
         fields = ['start_time', 'end_time']
 
 
-class StylistSerializer(UserSerializer):
+class StylistSerializer(GeneralUserSerializer):
 
     class Meta:
         model = User
-        fields = ['pk', 'first_name', 'last_name']
+        fields = ['id', 'first_name', 'last_name']
 
 
-class CustomerSerializer(UserSerializer):
-
-    class Meta:
-        model = User
-        fields = ['pk', 'first_name', 'last_name']
-
-
-class ManagerSerializer(UserSerializer):
+class CustomerSerializer(GeneralUserSerializer):
 
     class Meta:
         model = User
-        fields = ['pk', 'first_name', 'last_name']
+        fields = ['id', 'first_name', 'last_name']
+
+
+class ManagerSerializer(GeneralUserSerializer):
+
+    class Meta:
+        model = User
+        fields = ['id', 'first_name', 'last_name']
 
 
 class DailyScheduleSerializer(serializers.ModelSerializer):
@@ -54,7 +58,7 @@ class DailyScheduleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DailySchedule
-        fields = ['date', 'stylist', 'pk', 'timeslots']
+        fields = ['id', 'date', 'stylist', 'timeslots']
 
     def create(self, validated_data):
         timeslots_data = validated_data.pop('timeslots')
@@ -75,12 +79,12 @@ class DailyScheduleSerializer(serializers.ModelSerializer):
 
 
 class ServiceSerializer(serializers.ModelSerializer):
-    pk = serializers.PrimaryKeyRelatedField(read_only=True)
+    id = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Service
         # fields = "__all__"
-        fields = ['pk', 'serviceName', 'defaultDuration', 'description']
+        fields = ['id', 'serviceName', 'defaultDuration', 'description']
 
     def create(self, validated_data):
         return Service.objects.create(**validated_data)

--- a/express_cut/express_service/serializers.py
+++ b/express_cut/express_service/serializers.py
@@ -20,7 +20,7 @@ class GeneralUserSerializer(serializers.ModelSerializer):
         instance.password = validated_data.get('password', instance.password)
         instance.first_name = validated_data.get('first_name', instance.first_name)
         instance.last_name = validated_data.get('last_name', instance.last_name)
-        instance.last_name = validated_data.get('email', instance.email)
+        instance.email = validated_data.get('email', instance.email)
         instance.save()
         return instance
 
@@ -94,7 +94,6 @@ class ServiceSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Service
-        # fields = "__all__"
         fields = ['id', 'serviceName', 'defaultDuration', 'description']
 
     def create(self, validated_data):

--- a/express_cut/express_service/views.py
+++ b/express_cut/express_service/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.http import HttpResponse
 from .models import User, Reservation, DailySchedule
-from .serializers import UserSerializer, ReservationSerializer, DailyScheduleSerializer
+from .serializers import GeneralUserSerializer, SingUpUserSerializer,  ReservationSerializer, DailyScheduleSerializer
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -12,7 +12,7 @@ from drf_yasg.utils import swagger_auto_schema
 from .swagger_models import SwagResponses as swagResp
 
 
-@swagger_auto_schema(methods=['POST'], request_body=UserSerializer, responses=swagResp.commonPOSTResponses,
+@swagger_auto_schema(methods=['POST'], request_body=SingUpUserSerializer, responses=swagResp.commonPOSTResponses,
                      tags=['user'], )
 @api_view(['POST'])
 @authentication_classes([SessionAuthentication, BasicAuthentication])
@@ -21,7 +21,7 @@ def user_signup_view(request):
     Signup a users in the system.
     """
     data = request.data
-    serializer = UserSerializer(data=data)
+    serializer = SingUpUserSerializer(data=data)
     if not serializer.is_valid():
         return Response({"message": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
     if not SignUpPermissions().POST_permissions(request, serializer.validated_data):
@@ -32,7 +32,7 @@ def user_signup_view(request):
     return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@swagger_auto_schema(methods=['GET'], responses={**swagResp.commonResponses, **swagResp.getResponse(UserSerializer)}, tags=['user'], )
+@swagger_auto_schema(methods=['GET'], responses={**swagResp.commonResponses, **swagResp.getResponse(GeneralUserSerializer)}, tags=['user'], )
 @api_view(['GET', ])
 @authentication_classes([SessionAuthentication, BasicAuthentication])
 @permission_classes([IsAuthenticated])
@@ -51,13 +51,13 @@ def all_users(request):
             users.filter(role=User.CUSTOMER)
         elif role == User.MANAGER:
             users.filter(role=User.MANAGER)
-        serializer = UserSerializer(users, many=True)
+        serializer = GeneralUserSerializer(users, many=True)
         return Response(serializer.data, status=status.HTTP_302_FOUND)
 
 
-@swagger_auto_schema(methods=['PUT'], request_body=UserSerializer, responses={**swagResp.commonResponses, **swagResp.getResponse(UserSerializer)},
+@swagger_auto_schema(methods=['PUT'], request_body=GeneralUserSerializer, responses={**swagResp.commonResponses, **swagResp.getResponse(GeneralUserSerializer)},
                      tags=['user'], )
-@swagger_auto_schema(methods=['GET', 'DELETE'], responses={**swagResp.commonResponses, **swagResp.getResponse(UserSerializer)},)
+@swagger_auto_schema(methods=['GET', 'DELETE'], responses={**swagResp.commonResponses, **swagResp.getResponse(GeneralUserSerializer)},)
 @api_view(['GET', 'PUT', 'DELETE'])
 @authentication_classes([SessionAuthentication, BasicAuthentication])
 @permission_classes([IsAuthenticated])
@@ -70,13 +70,13 @@ def users_views(request, pk):
     if request.method == 'GET':
         if not UserViewPermissions().GET_permissions(request, usr_obj):
             return Response(status=status.HTTP_403_FORBIDDEN)
-        serializer = UserSerializer(usr_obj)
+        serializer = GeneralUserSerializer(usr_obj)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     elif request.method == 'PUT':
         if not UserViewPermissions().PUT_permissions(request, usr_obj):
             return Response(status=status.HTTP_403_FORBIDDEN)
-        serializer = UserSerializer(usr_obj, data=request.data)
+        serializer = GeneralUserSerializer(usr_obj, data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -171,7 +171,7 @@ def schedule_views(request):
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@swagger_auto_schema(methods=['GET', 'DELETE'], responses={**swagResp.commonResponses, **swagResp.getResponse(UserSerializer)},tags=['dailySchedule'],)
+@swagger_auto_schema(methods=['GET', 'DELETE'], responses={**swagResp.commonResponses, **swagResp.getResponse(DailyScheduleSerializer)},tags=['dailySchedule'],)
 @swagger_auto_schema(methods=['PUT'], request_body=DailyScheduleSerializer, responses=swagResp.commonPOSTResponses,
                      tags=['dailySchedule'], )
 @api_view(['GET', 'PUT', 'DELETE'])

--- a/express_cut/express_service/views.py
+++ b/express_cut/express_service/views.py
@@ -52,7 +52,7 @@ def all_users(request):
         elif role == User.MANAGER:
             users.filter(role=User.MANAGER)
         serializer = GeneralUserSerializer(users, many=True)
-        return Response(serializer.data, status=status.HTTP_302_FOUND)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 @swagger_auto_schema(methods=['PUT'], request_body=GeneralUserSerializer, responses={**swagResp.commonResponses, **swagResp.getResponse(GeneralUserSerializer)},


### PR DESCRIPTION
When doing a PUT for the user route it was require to pass the password in the request. As a fix users have two serializes: One intended for signup only and another one for PUT, DELETE and GET of Users.